### PR TITLE
Update 5.6 from 5.6.30 to 5.6.31

### DIFF
--- a/php5.6-nts.json
+++ b/php5.6-nts.json
@@ -1,15 +1,15 @@
 {
   "homepage": "http://windows.php.net/downloads/releases/",
-  "version": "5.6.30",
+  "version": "5.6.31",
   "license": "http://www.php.net/license/3_01.txt",
   "architecture": {
     "64bit": {
-      "url": "http://windows.php.net/downloads/releases/php-5.6.30-nts-Win32-VC11-x64.zip",
-      "hash": "19e6979922b642344131582d83d331348eb8ba1a44c723ef3b2cd9aee36e0c29"
+      "url": "http://windows.php.net/downloads/releases/php-5.6.31-nts-Win32-VC11-x64.zip",
+      "hash": "ca7d84d6b89e7f61391875b8a50c12a70d3047b818d81a9b2e8d5bd1388462fb"
     },
     "32bit": {
-      "url": "http://windows.php.net/downloads/releases/php-5.6.30-nts-Win32-VC11-x86.zip",
-      "hash": "17c22fd4031e28244e43daeab83aa2c38dc1c83ad63da14bcfbb9fdc490816a9"
+      "url": "http://windows.php.net/downloads/releases/php-5.6.31-nts-Win32-VC11-x86.zip",
+      "hash": "6d4f973fae39aaba6d974944a9b9458091b3731274376b94b58f9978cd812ea7"
     }
   },
   "bin": [

--- a/php5.6.json
+++ b/php5.6.json
@@ -1,15 +1,15 @@
 {
   "homepage": "http://windows.php.net/downloads/releases/",
-  "version": "5.6.30",
+  "version": "5.6.31",
   "license": "http://www.php.net/license/3_01.txt",
   "architecture": {
     "64bit": {
-      "url": "http://windows.php.net/downloads/releases/php-5.6.30-Win32-VC11-x64.zip",
-      "hash": "f1fe989702f71e2ce72413ec0875545db7d6251cfc5f00862c8e8c86b581adbe"
+      "url": "http://windows.php.net/downloads/releases/php-5.6.31-Win32-VC11-x64.zip",
+      "hash": "3b333cd4a1e44edf398cde84697c6a9f4806d49dc3e9d48859569d4b2b211c64"
     },
     "32bit": {
-      "url": "http://windows.php.net/downloads/releases/php-5.6.30-Win32-VC11-x86.zip",
-      "hash": "287c4d6807c4b3f2917c8f331a0869bc2d17f7e5d7add4e0cb32ddaa81693992"
+      "url": "http://windows.php.net/downloads/releases/php-5.6.31-Win32-VC11-x86.zip",
+      "hash": "4813e4bcb76060fcf7dd1d9f3b465dbcc32997d8d70a74d3a68919a4d8fd0338"
     }
   },
   "bin": [


### PR DESCRIPTION
The 5.6.30 executables were giving me 404 errors, since they have been moved into the archives directory at http://windows.php.net/downloads/releases/archives/ 